### PR TITLE
Add initial version of focus events pump

### DIFF
--- a/focus-events-pump/.dockerignore
+++ b/focus-events-pump/.dockerignore
@@ -1,0 +1,13 @@
+**/.git/
+**/.idea/
+*.iws
+
+
+**/__pycache__/
+*.py[cod]
+*$py.class
+
+*.so
+
+**/.venv*
+**/venv/

--- a/focus-events-pump/.environment.variables.sh
+++ b/focus-events-pump/.environment.variables.sh
@@ -1,0 +1,12 @@
+export MQTT_HOST='localhost'
+export MQTT_PORT=1883
+export FOCUS_TOPIC='customer/focus'
+
+export PERIODIC_TASKS_INTERVAL=0.05
+export GENERATOR_AUTO_START=true
+
+
+export TESTING_NO_MQTT=false
+export TESTING_NO_POSTGRES=true
+
+export LOG_LEVEL=INFO

--- a/focus-events-pump/.gitignore
+++ b/focus-events-pump/.gitignore
@@ -1,0 +1,15 @@
+*.log
+__pycache__/
+*__pycache__/
+*.py[cod]
+*$py.class
+*.idea/
+*.vscode/
+*.iws
+*.iml
+
+*.priv.*
+*.priv
+
+venv/
+.venv*/

--- a/focus-events-pump/Dockerfile
+++ b/focus-events-pump/Dockerfile
@@ -1,0 +1,11 @@
+FROM bitnami/python:3.11
+
+WORKDIR /code
+
+COPY ./requirements.txt /code/requirements.txt
+
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+
+COPY ./app /code/app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/focus-events-pump/Dockerfile
+++ b/focus-events-pump/Dockerfile
@@ -1,5 +1,7 @@
 FROM bitnami/python:3.11
 
+EXPOSE 80
+
 WORKDIR /code
 
 COPY ./requirements.txt /code/requirements.txt

--- a/focus-events-pump/README.md
+++ b/focus-events-pump/README.md
@@ -1,0 +1,63 @@
+# Focus Events Generator
+
+This is a helper service that generates focus events (for the recommendation service)
+and publishes them to an MQTT topic. The service is intended to be used for load testing Recommendation Service.
+
+The topic and the frequency of events can be configured via environment variables.
+
+The message payload is a JSON object with the following structure (see Recommendation Service project's README):
+```json
+{
+  "id": "4",
+  "dep": "Boys",
+  "ts": 192322800
+}
+```
+
+## Service configuration
+
+The service reads the following **environment variables**:
+
+| Variable                | Description                          | Default |
+|-------------------------|--------------------------------------|--------:|
+| MQTT_HOST               | comma-separated list of MQTT brokers |       - |
+| MQTT_PORT               | MQTT brokers' port                   |    	  - |
+| MQTT_USERNAME           | MQTT user username                   |    None |
+| MQTT_PASSWORD           | MQTT user password                   |    None |
+| MQTT_BROKER_CERT_FILE   | path to MQTT ssl cert file           |    None |
+| FOCUS_TOPIC             | topic for focus events               |    	  - |
+| PERIODIC_TASKS_INTERVAL | repeat publication every n seconds   |    	  1 |
+| GENERATOR_AUTO_START    | start generating when the app starts |    True |
+| LOG_LEVEL               | logging level                        |    INFO |
+
+(Parameters with `-` in the "Default" column are required.)
+
+Use [log_config.py](./app/utils/log_config.py) to **configure logging behaviour**. 
+By default, console and file handlers are used. The file appender writes to `messages.log`.
+
+## Running the service
+
+For development, I created a project with a dedicated virtual environment (Python 3.8, all the dependencies installed
+there).
+
+The code reads sensitive information (tokens, secrets) from environment variables. They need to be set accordingly in
+advance.
+`.environment.variables.sh` can be used for that purpose. Then, in order to run the service the following commands can be
+used:
+
+```bash
+$ . .environment.variables.sh
+$ . venv/bin/activate
+(venv)$ uvicorn app.main:app --host 0.0.0.0 --reload --reload-dir app
+```
+> Please, note `reload-dir` switch. Without it the reloader goes into an infinite loop because it detects log file changes (messages.log).
+
+## Testing without MQTT
+For testing/development purposes, you can use a dummy MQTT client that does not connect to a real broker.
+
+In order for the service not to create real MQTT producers, set `TESTING_NO_MQTT` environment variable to "true".
+
+
+## TODO
+* Describe the service's API (http)
+* Dockerize the service

--- a/focus-events-pump/README.md
+++ b/focus-events-pump/README.md
@@ -15,6 +15,20 @@ The message payload is a JSON object with the following structure (see Recommend
 }
 ```
 
+Please, note that this implementation is not universal. It is tailored to the needs of the
+demo that uses predefined dataset (customers, coupons, etc.). The service assumes that the system operates on the same
+dataset that CacheDB loader uses. (see: [CacheDB loader data](../cachedb-load-data/data))
+
+Some of the characteristics of clients data are:
+* there are 1000 clients
+* ids of clients are integers from 1 to 1000
+
+This allows for great simplifications -- instead of choosing from the actual set of clients' ids, the service can simply
+generate random integers in the range [1, 1000].
+
+Also, the generated message format is "static", not configurable. Which is enough for this simple purpose.
+
+
 ## Usage
 
 This is a web service (implemented with FastAPI). By default, it works on port 8000.

--- a/focus-events-pump/README.md
+++ b/focus-events-pump/README.md
@@ -6,6 +6,7 @@ and publishes them to an MQTT topic. The service is intended to be used for load
 The topic and the frequency of events can be configured via environment variables.
 
 The message payload is a JSON object with the following structure (see Recommendation Service project's README):
+
 ```json
 {
   "id": "4",
@@ -14,7 +15,45 @@ The message payload is a JSON object with the following structure (see Recommend
 }
 ```
 
-## Service configuration
+## Usage
+
+This is a web service (implemented with FastAPI). By default, it works on port 8000.
+(See [instructions](#running-the-service) for details on configuring and running the service.)
+
+When starting, it does the following:
+
+* connects to MQTT server
+* creates a background task that periodically generates focus event payload and publishes it to MQTT topic
+
+The message production starts automatically (when the service starts), unless `GENERATOR_AUTO_START` environment
+variable is set to `False`.
+
+Message publication can be paused and resumed by sending a POST request to `/stop` and `/start` endpoints respectively.
+
+### HTTP endpoints
+
+The service exposes the following HTTP endpoints:
+
+| Method | Path         | Function                       |
+|--------|--------------|--------------------------------|
+| GET    | /healthcheck | can be used for liveness probe |
+| POST   | /start       | start message publications     |
+| POST   | /stop        | pause message publications     |
+
+## Development
+
+Dependencies of the project are contained in [requirements.txt](requirements.txt) file. All the packages are publicly
+available.
+For development, it may be convenient to have a dedicated virtual environment (Python 3.8+, all the dependencies
+installed there).
+
+```bash
+python3 -m venv venv
+. venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Service configuration
 
 The service reads the following **environment variables**:
 
@@ -32,32 +71,29 @@ The service reads the following **environment variables**:
 
 (Parameters with `-` in the "Default" column are required.)
 
-Use [log_config.py](./app/utils/log_config.py) to **configure logging behaviour**. 
+Use [log_config.py](./app/config/log_config.py) to **configure logging behaviour**.
 By default, console and file handlers are used. The file appender writes to `messages.log`.
 
 ## Running the service
 
-For development, I created a project with a dedicated virtual environment (Python 3.8, all the dependencies installed
-there).
-
 The code reads sensitive information (tokens, secrets) from environment variables. They need to be set accordingly in
-advance.
-`.environment.variables.sh` can be used for that purpose. Then, in order to run the service the following commands can be
+advance. `environment.variables.sh` can be used for that purpose. Then, in order to run the service the following
+commands can be
 used:
 
-```bash
+```shell
 $ . .environment.variables.sh
 $ . venv/bin/activate
 (venv)$ uvicorn app.main:app --host 0.0.0.0 --reload --reload-dir app
 ```
-> Please, note `reload-dir` switch. Without it the reloader goes into an infinite loop because it detects log file changes (messages.log).
+
+> Please, note `reload-dir` switch. Without it the reloader goes into an infinite loop because it detects log file
+> changes (messages.log).
 
 ## Testing without MQTT
-For testing/development purposes, you can use a dummy MQTT client that does not connect to a real broker.
+
+For testing/development purposes, you can use a dummy MQTT client that does not connect to a real broker. 
+Instead, it prints the messages to the console.
 
 In order for the service not to create real MQTT producers, set `TESTING_NO_MQTT` environment variable to "true".
 
-
-## TODO
-* Describe the service's API (http)
-* Dockerize the service

--- a/focus-events-pump/app/__init__.py
+++ b/focus-events-pump/app/__init__.py
@@ -1,0 +1,1 @@
+from app.config.log_config import logger

--- a/focus-events-pump/app/config/__init__.py
+++ b/focus-events-pump/app/config/__init__.py
@@ -1,0 +1,29 @@
+import inspect
+import os
+import sys
+
+
+def dump_constants(logger_func, hidden_keys):
+    def is_empty(v):
+        return v is None or v == ''
+
+    logger_func("dumping constants...")
+    frame = inspect.currentframe()
+    globals = frame.f_back.f_globals  # globals()
+    constants_keys = [k for k in globals.keys() if k[0].isupper()]
+    for k in constants_keys:
+        global_value = globals.get(k)
+        value = global_value if not is_empty(global_value) else ''
+        if k in hidden_keys:
+            value = len(value) * "*"
+        logger_func(f'{k} = {value}')
+
+
+def validate_and_crash(logger_func, variable, message):
+    if not variable:
+        logger_func(message)
+        sys.exit(message)
+
+
+def get_bool_env(env_name: str, default: bool = False) -> bool:
+    return os.getenv(env_name, str(default)).lower() in ['1', 'yes', 'true']

--- a/focus-events-pump/app/config/config.py
+++ b/focus-events-pump/app/config/config.py
@@ -1,0 +1,45 @@
+import os
+
+from app import logger
+from app.config import dump_constants, validate_and_crash, get_bool_env
+
+logger.info('Reading environment variables...')
+
+FOCUS_TOPIC = os.getenv('FOCUS_TOPIC')
+MQTT_HOST = os.getenv('MQTT_HOST')
+MQTT_PORT = os.getenv('MQTT_PORT', 1881)
+MQTT_USERNAME = os.getenv('MQTT_USERNAME')
+MQTT_PASSWORD = os.getenv('MQTT_PASSWORD')
+MQTT_BROKER_CERT_FILE = os.getenv('MQTT_BROKER_CERT_FILE')
+
+DB_NAME = os.getenv('DB_NAME')
+DB_USER = os.getenv('DB_USER')
+DB_PASSWORD = os.getenv('DB_PASSWORD')
+DB_HOST = os.getenv('DB_HOST')
+DB_PORT = os.getenv('DB_PORT')
+
+TESTING_NO_MQTT = get_bool_env('TESTING_NO_MQTT', False)
+TESTING_NO_POSTGRES = get_bool_env('TESTING_NO_POSTGRES', True)
+
+# TODO: read from env
+DEPARTMENTS = ['Women', 'Boys', 'Sport', 'Girls', 'Men']
+
+PERIODIC_TASKS_INTERVAL = float(os.getenv('PERIODIC_TASKS_INTERVAL', 1.0))
+
+GENERATOR_AUTO_START = get_bool_env('GENERATOR_AUTO_START', True)
+
+HIDDEN_CONSTANTS_KEYS = ['DB_PASSWORD', 'MQTT_PASSWORD']
+
+dump_constants(logger.info, HIDDEN_CONSTANTS_KEYS)
+# dump_constants(print, hidden_keys)
+
+REQUIRED_PARAM_MESSAGE = 'Cannot read {} env variable. Please, make sure it is set before starting the service.'
+
+if not TESTING_NO_MQTT:
+    validate_and_crash(logger.error, FOCUS_TOPIC, REQUIRED_PARAM_MESSAGE.format('FOCUS_TOPIC'))
+    validate_and_crash(logger.error, MQTT_HOST, REQUIRED_PARAM_MESSAGE.format('MQTT_HOST'))
+
+if not TESTING_NO_POSTGRES:
+    validate_and_crash(logger.error, DB_HOST, REQUIRED_PARAM_MESSAGE.format('DB_HOST'))
+
+logger.info("Environment variables read successfully.")

--- a/focus-events-pump/app/config/config.py
+++ b/focus-events-pump/app/config/config.py
@@ -23,7 +23,8 @@ TESTING_NO_POSTGRES = get_bool_env('TESTING_NO_POSTGRES', True)
 
 # TODO: read from env
 DEPARTMENTS = ['Women', 'Boys', 'Sport', 'Girls', 'Men']
-
+MIN_CUSTOMER_ID = int(os.getenv('MIN_CUSTOMER_ID', 1))
+MAX_CUSTOMER_ID = int(os.getenv('MAX_CUSTOMER_ID', 1000))
 PERIODIC_TASKS_INTERVAL = float(os.getenv('PERIODIC_TASKS_INTERVAL', 1.0))
 
 GENERATOR_AUTO_START = get_bool_env('GENERATOR_AUTO_START', True)
@@ -31,7 +32,6 @@ GENERATOR_AUTO_START = get_bool_env('GENERATOR_AUTO_START', True)
 HIDDEN_CONSTANTS_KEYS = ['DB_PASSWORD', 'MQTT_PASSWORD']
 
 dump_constants(logger.info, HIDDEN_CONSTANTS_KEYS)
-# dump_constants(print, hidden_keys)
 
 REQUIRED_PARAM_MESSAGE = 'Cannot read {} env variable. Please, make sure it is set before starting the service.'
 

--- a/focus-events-pump/app/config/log_config.py
+++ b/focus-events-pump/app/config/log_config.py
@@ -1,0 +1,29 @@
+import logging
+import os
+
+LOG_FILENAME = "messages.log"
+LOG_FORMAT = "%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]\t%(message)s"
+LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO').upper()
+LOGGER_NAME = 'app.utils'
+
+assert LOG_LEVEL in ['DEBUG', 'INFO', 'WARNING', 'ERROR']
+
+logging.basicConfig(format=LOG_FORMAT, level=LOG_LEVEL)
+
+# Basic console logger
+logger = logging.getLogger(LOGGER_NAME)
+
+# File logger
+logFormatter = logging.Formatter(LOG_FORMAT)
+
+fileHandler = logging.FileHandler(LOG_FILENAME, encoding='UTF-8')
+fileHandler.setFormatter(logFormatter)
+
+logger.addHandler(fileHandler)
+
+# Disable APScheduler logs
+logging.getLogger('apscheduler').setLevel(logging.WARN)
+
+# Configuration done
+logger.info(f"Configuring logger with LOG_LEVEL={LOG_LEVEL}")
+logger.debug("Logger configured...")

--- a/focus-events-pump/app/generator.py
+++ b/focus-events-pump/app/generator.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
+from app.config.config import MIN_CUSTOMER_ID, MAX_CUSTOMER_ID
+
 
 class FocusEvent(BaseModel):
     customer_id: str = Field(alias='id')
@@ -17,7 +19,7 @@ class FocusEventGenerator:
     def __init__(self, available_dep_list: list[str], pick_customer_func=None):
         self.available_dep_list = available_dep_list
         if pick_customer_func is None:
-            self.pick_customer_func = lambda: randint(1, 997)
+            self.pick_customer_func = lambda: randint(MIN_CUSTOMER_ID, MAX_CUSTOMER_ID)
         else:
             self.pick_customer_func = pick_customer_func
 

--- a/focus-events-pump/app/generator.py
+++ b/focus-events-pump/app/generator.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from random import choice, randint
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class FocusEvent(BaseModel):
+    customer_id: str = Field(alias='id')
+    ts: int
+    dep: str
+    x: Optional[int]
+    y: Optional[int]
+
+
+class FocusEventGenerator:
+    def __init__(self, available_dep_list: list[str], pick_customer_func=None):
+        self.available_dep_list = available_dep_list
+        if pick_customer_func is None:
+            self.pick_customer_func = lambda: randint(1, 997)
+        else:
+            self.pick_customer_func = pick_customer_func
+
+    def generate(self) -> FocusEvent:
+        timestamp = datetime.now().timestamp()
+        department = choice(self.available_dep_list)
+        customer_id = self.pick_customer_func()
+
+        return FocusEvent(id=customer_id, ts=timestamp, dep=department, x=None, y=None)

--- a/focus-events-pump/app/main.py
+++ b/focus-events-pump/app/main.py
@@ -1,0 +1,84 @@
+import logging
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+
+from app import logger
+from app.config.config import PERIODIC_TASKS_INTERVAL, DEPARTMENTS, FOCUS_TOPIC, GENERATOR_AUTO_START
+from app.generator import FocusEventGenerator
+from app.mqtt.mqtt import initialize_mqtt
+
+app = FastAPI()
+mqtt = initialize_mqtt(app)
+
+####################
+# web handlers
+logger.info('Defining web service handlers...')
+
+
+@app.get('/healthcheck')
+async def healthcheck():
+    """
+    Service health check endpoint.
+    """
+    logger.info('verify health')
+    return PlainTextResponse('OK')
+
+
+@app.get("/")
+async def root():
+    return {"message": "Hello World"}
+
+
+@app.post('/start')
+async def start_generator():
+    logger.info('start_generator')
+    result = "OK"
+    if app.state.generator_enabled:
+        result = "Generator is already enabled"
+    else:
+        app.state.generator_enabled = True
+
+    return PlainTextResponse(result)
+
+
+@app.post('/stop')
+async def stop_generator():
+    logger.info('stop_generator')
+    result = "OK"
+    if not app.state.generator_enabled:
+        result = "Generator is already disabled"
+    else:
+        app.state.generator_enabled = False
+
+    return PlainTextResponse(result)
+
+
+####################
+# utility functions
+def tick():
+    logger.debug("tick")
+    if not app.state.generator_enabled:
+        logger.debug("Generator is disabled")
+    else:
+        logger.info("Publishing a new event")
+        event = app.state.message_generator.generate()
+        payload = event.json(by_alias=True, exclude_none=True).encode()
+        logger.debug(f"event: {payload}")
+        mqtt.publish(FOCUS_TOPIC, payload)
+
+
+#####
+# App startup and shutdown
+@app.on_event('startup')
+async def init_app():
+    logger.info("Initializing the app")
+    app.state.message_generator = FocusEventGenerator(DEPARTMENTS)
+    app.state.generator_enabled = GENERATOR_AUTO_START
+
+    logger.info("Starting the scheduler")
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(tick, 'interval', seconds=PERIODIC_TASKS_INTERVAL)
+    scheduler.start()

--- a/focus-events-pump/app/mqtt/dummy_mqtt.py
+++ b/focus-events-pump/app/mqtt/dummy_mqtt.py
@@ -1,0 +1,27 @@
+from typing import Callable
+
+from app import logger
+
+
+class DummyMQTT:
+
+    def __init__(self):
+        logger.warning('- ' * 20)
+        logger.warning('')
+        logger.warning('Initializing Dummy MQTT connection.')
+        logger.warning('')
+        logger.warning('- ' * 20)
+
+    def subscribe(self, *topics):
+        def func(handler: Callable) -> Callable:
+            logger.info(f'Dummy MQTT subscribe to {topics}')
+            return handler
+        return func
+
+    def publish(self, topic, payload):
+        logger.info('Dummy MQTT publishing message:')
+        logger.info(f'Topic: {topic}; Message: {payload}')
+        return {
+            'topic': topic,
+            'payload': payload
+        }

--- a/focus-events-pump/app/mqtt/mqtt.py
+++ b/focus-events-pump/app/mqtt/mqtt.py
@@ -1,0 +1,33 @@
+from fastapi_mqtt import MQTTConfig, FastMQTT
+from gmqtt.mqtt.constants import MQTTv311
+import ssl
+
+from app import logger
+from app.config import config
+from app.mqtt.dummy_mqtt import DummyMQTT
+
+
+def initialize_mqtt(fastapi_app):
+    logger.info("Initializing MQTT...")
+    if not config.TESTING_NO_MQTT:
+        logger.info(f'MQTT host: {config.MQTT_HOST}:{config.MQTT_PORT} | user: {config.MQTT_USERNAME}')
+        context = False
+        if config.MQTT_BROKER_CERT_FILE is not None:
+            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+            context.load_verify_locations(config.MQTT_BROKER_CERT_FILE)
+        mqtt_config = MQTTConfig(
+            host=config.MQTT_HOST,
+            port=config.MQTT_PORT,
+            username=config.MQTT_USERNAME,
+            password=config.MQTT_PASSWORD,
+            # TODO XXX consider using MQTTv5 (parametrize this setting)
+            version=MQTTv311,
+            ssl=context)
+        mqtt = FastMQTT(config=mqtt_config)
+        mqtt.init_app(fastapi_app)
+
+    else:
+        logger.warning('MQTT is disabled (TESTING_NO_MQTT is set to True)')
+        mqtt = DummyMQTT()
+
+    return mqtt

--- a/focus-events-pump/mosquitto-in-docker.md
+++ b/focus-events-pump/mosquitto-in-docker.md
@@ -1,0 +1,51 @@
+Run vanilla mosquitto in docker:
+```bash
+docker run -it --name mosquitto -p 1883:1883 eclipse-mosquitto 
+```
+
+Running the broker with websockets on, persistence and proper listener configuration (port 1883) requires config like:
+```
+# mosquitto.conf file
+listener 1883
+
+listener 9001
+protocol websockets
+
+allow_anonymous true
+persistence true
+persistence_location /mosquitto/data
+
+# log_dest file /mosquitto/log/mosquitto.log
+log_dest stdout
+log_dest topic
+connection_messages true
+
+```
+
+```bash
+docker run -it -p 1883:1883 -p 9001:9001 -v $(pwd)/mosquitto.conf:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log eclipse-mosquitto
+```
+
+The same, but non-interactive:
+```bash
+docker run --name mosquitto -d -p 1883:1883 -v $(pwd)/mosquitto.conf:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log eclipse-mosquitto
+```
+
+
+The client (sub):
+```bash
+docker run -it --net=host eclipse-mosquitto mosquitto_sub -h localhost -t example/topic
+```
+
+
+
+The client (pub):
+```bash
+
+docker run -it --net=host eclipse-mosquitto mosquitto_pub -h localhost -t example/topic -m "Hello World"
+```
+
+Publish 100 messages:
+```bash
+for i in {1..100}; do docker run -it --net=host eclipse-mosquitto mosquitto_pub -h localhost -t example/topic -m "Hello World $i"; done
+```

--- a/focus-events-pump/requirements.txt
+++ b/focus-events-pump/requirements.txt
@@ -1,0 +1,6 @@
+APScheduler~=3.10.1
+aiopg==1.4.0
+anyio==3.6.2
+fastapi-mqtt~=1.0.7
+fastapi==0.94.1
+pydantic==1.10.6


### PR DESCRIPTION
The service is intended to be used for load testing Recommendation Service.
It generates focus events (randomly picking the customer and department) and publishes them to an MQTT topic.

- [ ] Describe the service's API (HTTP)
- [ ] Dockerize the service
- [ ] Rebase!!!