### PR TITLE
Describe interfaces; allow for control via MQTT topic [focus event pump]

### DIFF
--- a/focus-events-pump/.environment.variables.sh
+++ b/focus-events-pump/.environment.variables.sh
@@ -2,7 +2,7 @@ export MQTT_HOST='localhost'
 export MQTT_PORT=1883
 export FOCUS_TOPIC='customer/focus'
 
-export PERIODIC_TASKS_INTERVAL=0.05
+export PERIODIC_TASKS_INTERVAL=1.0
 export GENERATOR_AUTO_START=true
 
 export TESTING_NO_MQTT=false

--- a/focus-events-pump/README.md
+++ b/focus-events-pump/README.md
@@ -44,9 +44,9 @@ variable is set to `False`.
 
 Message publication can be paused and resumed by sending a POST request to `/stop` and `/start` endpoints respectively.
 
-### HTTP endpoints
+### Interfaces
 
-The service exposes the following HTTP endpoints:
+The service exposes the following **HTTP endpoints**:
 
 | Method | Path         | Function                       |
 |--------|--------------|--------------------------------|
@@ -54,6 +54,15 @@ The service exposes the following HTTP endpoints:
 | POST   | /start       | start message publications     |
 | POST   | /stop        | pause message publications     |
 | GET    | /state       | check generator status         |
+
+
+The service uses **MQTT topics** defined by the following(see [Service configuration](#service-configuration)):
+* `COMMAND_TOPIC` - the topic that the service listens to for incoming commands. The commands are used to control
+  the service's behavior. `start` and `stop` commands are supported. Using this way to 
+    control the service is especially useful when the service is deployed in a Kubernetes cluster and has multiple 
+    replicas. With one MQTT message, all the instances can be instructed to start/stop message production.
+* `FOCUS_TOPIC` - the topic that the service publishes focus events to.
+
 
 ## Development
 
@@ -72,18 +81,19 @@ pip install -r requirements.txt
 
 The service reads the following **environment variables**:
 
-| Variable                | Description                          | Default |
-|-------------------------|--------------------------------------|--------:|
-| MQTT_HOST               | comma-separated list of MQTT brokers |       - |
-| MQTT_PORT               | MQTT brokers' port                   |    1883 |
-| MQTT_USERNAME           | MQTT user username                   |    None |
-| MQTT_PASSWORD           | MQTT user password                   |    None |
-| MQTT_BROKER_CERT_FILE   | path to MQTT ssl cert file           |    None |
-| FOCUS_TOPIC             | topic for focus events               |       - |
-| PERIODIC_TASKS_INTERVAL | repeat publication every n seconds   |       1 |
-| GENERATOR_AUTO_START    | start generating when the app starts |    True |
-| LOG_LEVEL               | logging level                        |    INFO |
-| LOG_FILENAME            | log file name                        |      '' |
+| Variable                | Description                          |                Default |
+|-------------------------|--------------------------------------|-----------------------:|
+| MQTT_HOST               | comma-separated list of MQTT brokers |                      - |
+| MQTT_PORT               | MQTT brokers' port                   |                   1883 |
+| MQTT_USERNAME           | MQTT user username                   |                   None |
+| MQTT_PASSWORD           | MQTT user password                   |                   None |
+| MQTT_BROKER_CERT_FILE   | path to MQTT ssl cert file           |                   None |
+| FOCUS_TOPIC             | topic for focus events               |                      - |
+| COMMAND_TOPIC           | topic name for incoming commands     | focusEventPump/command |
+| PERIODIC_TASKS_INTERVAL | repeat publication every n seconds   |                      1 |
+| GENERATOR_AUTO_START    | start generating when the app starts |                   True |
+| LOG_LEVEL               | logging level                        |                   INFO |
+| LOG_FILENAME            | log file name                        |                     '' |
 
 (Parameters with `-` in the "Default" column are required.)
 
@@ -107,8 +117,7 @@ To increase the load, you can run multiple instances of the service, then.
 
 The code reads sensitive information (tokens, secrets) from environment variables. They need to be set accordingly in
 advance. `environment.variables.sh` can be used for that purpose. Then, in order to run the service the following
-commands can be
-used:
+commands can be used:
 
 ```shell
 $ . .environment.variables.sh
@@ -117,7 +126,7 @@ $ . venv/bin/activate
 ```
 
 > Please, note `reload-dir` switch. Without it the reloader goes into an infinite loop because it detects log file
-> changes (messages.log).
+> changes.
 
 ## Testing without MQTT
 

--- a/focus-events-pump/app/config/config.py
+++ b/focus-events-pump/app/config/config.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 from app import logger
 from app.config import dump_constants, validate_and_crash, get_bool_env
@@ -6,6 +7,7 @@ from app.config import dump_constants, validate_and_crash, get_bool_env
 logger.info('Reading environment variables...')
 
 FOCUS_TOPIC = os.getenv('FOCUS_TOPIC')
+COMMAND_TOPIC = os.getenv('COMMAND_TOPIC', 'focusEventPump/command')
 MQTT_HOST = os.getenv('MQTT_HOST')
 MQTT_PORT = os.getenv('MQTT_PORT', 1881)
 MQTT_USERNAME = os.getenv('MQTT_USERNAME')
@@ -13,6 +15,8 @@ MQTT_PASSWORD = os.getenv('MQTT_PASSWORD')
 MQTT_BROKER_CERT_FILE = os.getenv('MQTT_BROKER_CERT_FILE')
 # use 'MQTTv311' if your broker does not support MQTTv5
 MQTT_PROTOCOL_VERSION = os.getenv('MQTT_PROTOCOL_VERSION', 'MQTTv5')
+MQTT_CLIENT_ID = os.getenv('MQTT_CLIENT_ID', 'recSvc')
+MQTT_CLIENT_ID = f'{MQTT_CLIENT_ID}_{uuid.uuid4()}'
 
 DB_NAME = os.getenv('DB_NAME')
 DB_USER = os.getenv('DB_USER')

--- a/focus-events-pump/app/mqtt/mqtt.py
+++ b/focus-events-pump/app/mqtt/mqtt.py
@@ -4,7 +4,7 @@ import ssl
 
 from app import logger
 from app.config import config
-from app.config.config import MQTT_PROTOCOL_VERSION
+from app.config.config import MQTT_PROTOCOL_VERSION, MQTT_CLIENT_ID
 from app.mqtt.dummy_mqtt import DummyMQTT
 
 
@@ -25,7 +25,7 @@ def initialize_mqtt(fastapi_app):
             password=config.MQTT_PASSWORD,
             version=protocol_version,
             ssl=context)
-        mqtt = FastMQTT(config=mqtt_config)
+        mqtt = FastMQTT(config=mqtt_config, client_id=MQTT_CLIENT_ID)
         mqtt.init_app(fastapi_app)
 
     else:


### PR DESCRIPTION
Introduces MQTT command topic - the topic that the service listens to for incoming commands. 

The commands are used to control
the service's behavior. `start` and `stop` commands are supported. Using this way to 
control the service is especially useful when the service is deployed in a Kubernetes cluster and has multiple 
replicas. With one MQTT message, all the instances can be instructed to start/stop message production.